### PR TITLE
Add estimated savings column for Metrics

### DIFF
--- a/nerdlets/ingestimator-nerdlet/MetricsTable.js
+++ b/nerdlets/ingestimator-nerdlet/MetricsTable.js
@@ -1,14 +1,21 @@
 import React from "react"
 import { NrqlQuery, Spinner, Link, Icon, navigation } from 'nr1'
 
-import { APM_EVENTS, APM_TRACE_EVENTS, ESTIMATED_INGEST_GB, METRIC_EVENTS, WHERE_METRIC_APM } from "../shared/constants"
-import { estimatedCost, getResultValue, ingestRate } from "../shared/utils"
+import {
+  APM_EVENTS,
+  APM_TRACE_EVENTS,
+  ESTIMATED_INGEST_GB,
+  INEFFECTIVE_METRICS_PERCENTAGE,
+  METRIC_EVENTS,
+  WHERE_METRIC_APM
+} from "../shared/constants"
+import { estimatedCost, getResultValue, ingestRate, potentialSavings } from "../shared/utils"
 
 const LIMIT = 40
 
 
 export default function MetricsTableLoader({ accountId, since }) {
-  const query = `SELECT ${ESTIMATED_INGEST_GB}, cardinality() FROM ${METRIC_EVENTS} SINCE ${since} FACET metricName RAW LIMIT ${LIMIT}`
+  const query = `SELECT ${ESTIMATED_INGEST_GB}, cardinality(), ${INEFFECTIVE_METRICS_PERCENTAGE} FROM ${METRIC_EVENTS} SINCE ${since} FACET metricName RAW LIMIT ${LIMIT}`
   return <NrqlQuery accountId={accountId} query={query} formatType="raw">
     {({ loading, data }) => {
       if (loading || !data) return <Spinner />
@@ -17,8 +24,10 @@ export default function MetricsTableLoader({ accountId, since }) {
   </NrqlQuery>
 }
 
+const potentialSavingsDetector = (accumulator, row) => accumulator || getResultValue(row.results[2]) > 0;
 
 function MetricsTable({ rows }) {
+  const potentialSavingsPresent = rows.reduce(potentialSavingsDetector, false)
   return <div className="applications-table">
     <h4>Top Metrics by Ingest</h4>
     <table >
@@ -28,6 +37,9 @@ function MetricsTable({ rows }) {
           <th>Cardinality</th>
           <th>GB/mo</th>
           <th>Cost/mo</th>
+          { potentialSavingsPresent && (
+            <th>Potential Savings</th>
+           ) }
         </tr>
       </thead>
       <tbody>
@@ -36,6 +48,9 @@ function MetricsTable({ rows }) {
           <td className="right">{getResultValue(row.results[1])}</td>
           <td className="right">{ingestRate(getResultValue(row.results[0]))}</td>
           <td className="right">{estimatedCost(getResultValue(row.results[0]))}</td>
+          { potentialSavingsPresent && (
+            <td className="right">{potentialSavings(getResultValue(row.results[2]), getResultValue(row.results[0]))}</td>
+          )}
         </tr>)}
       </tbody>
     </table>

--- a/nerdlets/shared/constants.js
+++ b/nerdlets/shared/constants.js
@@ -9,6 +9,7 @@ export const METRIC_EVENTS = ['Metric', 'MetricRaw']
 
 // select clausess
 export const ESTIMATED_INGEST_GB = `rate(bytecountestimate(), 1 month)/1e9`
+export const INEFFECTIVE_METRICS_PERCENTAGE = `percentage(count(*), where (%[type]='summary' and %[count]=0) or (%[type]='gauge' and %[count]=1 and %[latest]=0))`
 
 // where clauses for metrics queries
 export const WHERE_METRIC_API = "newrelic.source = 'metricAPI'"

--- a/nerdlets/shared/utils.js
+++ b/nerdlets/shared/utils.js
@@ -35,17 +35,29 @@ export function ingestRate(value, hostCount) {
   return `${gigabytes(value)} /mo`
 }
 
+function tdpCost(value) {
+  return Math.round(value * 25) / 100;
+}
+
 export function estimatedCost(value, hostCount) {
   const suffix = "/mo"
   if (hostCount && hostCount > 0) {
     value = value / hostCount
   }
-  const cost = Math.round(value * 25) / 100
+  const cost = tdpCost(value)
   const dollars = cost.toLocaleString("en-US", { style: "currency", currency: "USD" });
 
   return `${dollars} ${suffix}`
 }
 
+export function potentialSavings(ineffectivePercentage, basisValue) {
+  const suffix = "/mo"
+  const ineffectiveGBs = (ineffectivePercentage / 100) * basisValue
+  const ineffectiveTdpCost = tdpCost(ineffectiveGBs)
+  const dollars = ineffectiveTdpCost.toLocaleString("en-US", { style: "currency", currency: "USD" })
+
+  return `${dollars} ${suffix}`
+}
 
 export function gigabytes(value, isDelta) {
   value = value * 1e9


### PR DESCRIPTION
Let's add an optional column for Metrics where we detect there is some interesting amount of potential savings to our customers. In this case, interesting is that there are ineffective metrics (e.g., summary metrics where the count=0) that can be eliminated.

The column is optional because it doesn't always exist. When it does, though, let's make sure we tell our customers.



